### PR TITLE
fixed imshow displaying on wrong axes

### DIFF
--- a/firstAzfpUnpack/azfpUnpack.py
+++ b/firstAzfpUnpack/azfpUnpack.py
@@ -1399,7 +1399,8 @@ class ZPLSPlot(object):
 
         ax.set_title(title, fontsize=ZPLSPlot.font_size_large)
         # return plt.imshow(ax, power_data, interpolation='none', aspect='auto', cmap='jet', vmin=min_db, vmax=max_db)
-        return plt.imshow(power_data, interpolation='none', aspect='auto', cmap='jet', vmin=min_db, vmax=max_db) # Complained about ax as arg
+        # return plt.imshow(power_data, interpolation='none', aspect='auto', cmap='jet', vmin=min_db, vmax=max_db)  # Complained about ax as arg
+        return ax.imshow(power_data, interpolation='none', aspect='auto', cmap='jet', vmin=min_db, vmax=max_db)
 
     @staticmethod
     def _display_x_labels(ax, data_times):


### PR DESCRIPTION
-Changed testAzfpUnpack to import azfpUnpack instead of azfpMarian (the old module name)
-Fixed the azfpUnpack script so that it displays the echograms on the correct axes